### PR TITLE
rewrite: overhaul arg parsing

### DIFF
--- a/headers/dump_elf_header.h
+++ b/headers/dump_elf_header.h
@@ -49,7 +49,7 @@ typedef struct elf_header {
 
 
 void dump_header(Elf_header header);
-Elf_header grab_elf_header(Args args);
+Elf_header grab_elf_header(Args args, char *fn);
 void check_and_set_magic(FILE *fd, Elf_header *header);
 uint64_t read_varaible_entries(FILE *fd, Elf_header header);
 

--- a/headers/dump_program_header.h
+++ b/headers/dump_program_header.h
@@ -20,10 +20,10 @@ typedef struct program_header {
 } Program_header;
 
 bool program_header_exists(Elf_header header);
-Program_header *grab_program_headers(Elf_header header, Args args);
-Program_header grab_program_header(Elf_header header, Args args, int index);
+Program_header *grab_program_headers(Elf_header header, Args args, char *fn);
 void navigate_fd_to_program_header(Elf_header header, FILE *fd);
 void navigate_fd_to_program_index(Elf_header header, FILE *fd, int i);
 void dump_program_headers(Program_header *ph, Elf_header eh, Args args);
+Program_header grab_program_header(Elf_header header, Args args, int index, char *fn);
 
 #endif

--- a/headers/dump_section_header.h
+++ b/headers/dump_section_header.h
@@ -29,9 +29,11 @@ typedef struct section_header {
 
 void navigate_fd_to_section_header(Elf_header header, FILE *fd);
 void navigate_fd_to_section_index(Elf_header header, FILE *fd, int index);
-Section_header grab_sect_header(Elf_header header, Args args, int index);
-Section_header *grab_all_section_headers(Elf_header header, Args args);
-void dump_section_headers(Section_header *headers, Elf_header elf_header, Args args);
-void print_and_format_section_header(Section_header shname, Section_header h, Elf_header elf_header, int i, Args args);
+Section_header grab_sect_header(Elf_header header, Args args, int index, char *fn);
+Section_header *grab_all_section_headers(Elf_header header, Args args, char *fn);
+void dump_section_headers(Section_header *headers, Elf_header elf_header, Args args, char *fn);
+void print_and_format_section_header(Section_header shname, Section_header h, Elf_header elf_header, int i, Args args,
+        char *fn);
+
 
 #endif

--- a/headers/dump_symbol_table.h
+++ b/headers/dump_symbol_table.h
@@ -14,7 +14,8 @@ typedef struct symtab_entry {
 } Symtab_entry;
 
 void navigate_fd_to_symbol_table(FILE *fd, Section_header sh);
-Hashmap **grab_symbol_table(Elf_header elf_header, Section_header *section_header, Args args);
-char *get_symbol_name(Elf_header ehead, Section_header shead, int offset, Args args);
+Hashmap **grab_symbol_table(Elf_header elf_header, Section_header *section_header, Args args,
+        char *fn);
+char *get_symbol_name(Elf_header ehead, Section_header shead, int offset, Args args, char *fn);
 
 #endif

--- a/headers/misc.h
+++ b/headers/misc.h
@@ -17,7 +17,7 @@ bool file_readable(char *path);
 void print_args(Args args);
 uint64_t read_nbytes(FILE *fd, Elf_header *header, int byte_count, bool variable);
 uint64_t read_nbytes_better(Elf_header header, FILE *fd, int bytes, bool variable);
-void DEBUG_DUMP_NBYTES(int offset, int n, Args args);
+void DEBUG_DUMP_NBYTES(int offset, int n, Args args, char *fn);
 void read_stream_until_null(FILE *fd);
 struct section_header get_section_entry(struct section_header *sh, Elf_header elf_header, int code);
 

--- a/headers/obj_metadata.h
+++ b/headers/obj_metadata.h
@@ -1,0 +1,23 @@
+#ifndef OBJ_METADATA_H
+#define OBJ_METADATA_H
+
+#include "dump_elf_header.h"
+#include "dump_symbol_table.h"
+#include "dump_program_header.h"
+#include "dump_section_header.h"
+
+typedef struct objdata {
+    char *path;
+    Elf_header eheader;
+    Section_header *sheaders;
+    Program_header *pheaders;
+    Hashmap **symtab;
+    struct objdata *next;
+} Objdata;
+
+
+Objdata *get_objdata(Args *args);
+Objdata *new_objdata(Elf_header e, Section_header *s, Program_header *p, Hashmap **sym, char *fn);
+void dump_objdata(Objdata *obj, Args args);
+
+#endif

--- a/headers/parse_args.h
+++ b/headers/parse_args.h
@@ -18,11 +18,13 @@ typedef struct filepath {
     char *filepath;
     int size;
     bool set;             // is set when valid filepath is set
+    struct filepath *next;
 } Filepath;
 
 
 typedef struct args {
-    Filepath path;
+    int file_count;
+    Filepath *path;
     bool dump_header;
     bool dump_section_header;
     bool dump_program_header;

--- a/headers/parse_args.h
+++ b/headers/parse_args.h
@@ -2,6 +2,7 @@
 #define PARSE_ARGS_H
 
 #include <stdbool.h>
+#include <argp.h>
 
 
 #define DUMP_HEADER_ARG "-h"

--- a/meson.build
+++ b/meson.build
@@ -4,10 +4,10 @@ deps = [
     'src/misc.c', 'src/parse_args.c',
     'src/dump_elf_header.c', 'src/dump_section_header.c',
     'src/dump_program_header.c', 'src/hashmap.c',
-    'src/dump_symbol_table.c'
+    'src/dump_symbol_table.c', 'src/objmeta.c'
     ]
 
-bin = executable('dump', 'src/main.c', deps)
+bin = executable('prom', 'src/main.c', deps)
 
 run_target(
     'run',

--- a/src/dump_elf_header.c
+++ b/src/dump_elf_header.c
@@ -47,9 +47,9 @@ void dump_header(Elf_header header) {
     printf("\tsection header string table index:\t%ld\n", header.e_shstrndx);
 }
 
-Elf_header grab_elf_header(Args args) {
+Elf_header grab_elf_header(Args args, char *fn) {
     Elf_header ret = {};
-    FILE *fd = fopen(args.path.filepath, "r");
+    FILE *fd = fopen(fn, "r");
     check_and_set_magic(fd, &ret);
     ret.ei_class = getc(fd);
     ret.ei_data = getc(fd);

--- a/src/dump_program_header.c
+++ b/src/dump_program_header.c
@@ -24,21 +24,21 @@ void navigate_fd_to_program_index(Elf_header header, FILE *fd, int i) {
     lseek(fileno(fd), i * header.e_phentsize, SEEK_CUR);
 }
 
-Program_header *grab_program_headers(Elf_header header, Args args) {
+Program_header *grab_program_headers(Elf_header header, Args args, char *fn) {
     Program_header *ret = calloc(sizeof(Program_header), header.e_phnum);
 
     for (int i = 0; i < header.e_phnum; i++) {
-        Program_header prog = grab_program_header(header, args, i);
+        Program_header prog = grab_program_header(header, args, i, fn);
         ret[i] = prog;
     }
 
     return ret;
 }
 
-Program_header grab_program_header(Elf_header header, Args args, int index) {
+Program_header grab_program_header(Elf_header header, Args args, int index, char *fn) {
     Program_header ret = {};
     uint8_t BYTE_FORMAT = header.ei_class;
-    FILE *fd = fopen(args.path.filepath, "r");
+    FILE *fd = fopen(fn, "r");
     navigate_fd_to_program_header(header, fd);
     navigate_fd_to_program_index(header, fd, index);
 

--- a/src/dump_section_header.c
+++ b/src/dump_section_header.c
@@ -16,9 +16,9 @@ void navigate_fd_to_section_header(Elf_header header, FILE *fd) {
     lseek(fileno(fd), entry_point, SEEK_SET);
 }
 
-Section_header grab_sect_header(Elf_header header, Args args, int index) {
+Section_header grab_sect_header(Elf_header header, Args args, int index, char *fn) {
     Section_header ret = {};
-    FILE *fd = fopen(args.path.filepath, "r");
+    FILE *fd = fopen(fn, "r");
     navigate_fd_to_section_header(header, fd);
     navigate_fd_to_section_index(header, fd, index);
 
@@ -37,18 +37,18 @@ Section_header grab_sect_header(Elf_header header, Args args, int index) {
     return ret;
 }
 
-Section_header *grab_all_section_headers(Elf_header header, Args args) {
+Section_header *grab_all_section_headers(Elf_header header, Args args, char *fn) {
     Section_header *all_headers = malloc(sizeof(Section_header) * header.e_shnum);
 
     for (int i = 0; i < header.e_shnum; i++) {
-        Section_header section = grab_sect_header(header, args, i);
+        Section_header section = grab_sect_header(header, args, i, fn);
         all_headers[i] = section;
     }
 
     return all_headers;
 }
 
-void dump_section_headers(Section_header *headers, Elf_header elf_header, Args args) {
+void dump_section_headers(Section_header *headers, Elf_header elf_header, Args args, char *fn) {
     printf("\n== section header dump ==\n\n");
     printf("elf header count: %ld\n"
             "shstrntab index: %ld\n\n", elf_header.e_shnum, elf_header.e_shstrndx);
@@ -57,7 +57,7 @@ void dump_section_headers(Section_header *headers, Elf_header elf_header, Args a
     printf("         "SH_FLAGS_ALIGN_STRING "       " SH_FLAGS_ALIGN_STRING "         " SH_FLAGS_ALIGN_STRING"", "addr", "offset", "size");
     printf("     "SH_FLAGS_ALIGN_STRING "     " SH_FLAGS_ALIGN_STRING "        "SH_FLAGS_ALIGN_STRING "      " SH_FLAGS_ALIGN_STRING"\n", "link", "info", "align", "entsize");
     for (int i = 0; i < elf_header.e_shnum; i++) {
-        print_and_format_section_header(headers[elf_header.e_shstrndx], headers[i], elf_header, i, args);
+        print_and_format_section_header(headers[elf_header.e_shstrndx], headers[i], elf_header, i, args, fn);
     }
 }
 
@@ -89,9 +89,10 @@ void print_sh_type_entry(uint64_t value) {
     printf(SH_TYPE_ALIGN_STRING, result);
 }
 
-void print_and_format_section_header(Section_header shname, Section_header h, Elf_header elf_header, int i, Args args) {
+void print_and_format_section_header(Section_header shname, Section_header h, Elf_header elf_header, int i, Args args,
+        char *fn) {
     int addr = shname.sh_offset + h.sh_name;
-    FILE *fd = fopen(args.path.filepath, "r");
+    FILE *fd = fopen(fn, "r");
     lseek(fileno(fd), addr, SEEK_SET);
 
     printf("[%2d] ", i);

--- a/src/dump_symbol_table.c
+++ b/src/dump_symbol_table.c
@@ -23,14 +23,14 @@ Elf64_Sym read_symbol_entry(FILE *fd, Section_header sh_symtab, Elf_header heade
     return ret;
 }
 
-char *get_symbol_name(Elf_header ehead, Section_header shead, int offset, Args args) {
+char *get_symbol_name(Elf_header ehead, Section_header shead, int offset, Args args, char *fn) {
     Section_header strtab = shead;
     char buf[10000] = {};
     int i = 0;
     int len;
     char c;
     int file_offset = strtab.sh_offset;
-    FILE *fd = fopen(args.path.filepath, "r");
+    FILE *fd = fopen(fn, "r");
 
     fseek(fd, file_offset + offset, SEEK_SET);
     while ((c = fgetc(fd)) != '\0' && i < 10000) {
@@ -50,9 +50,10 @@ char *get_symbol_name(Elf_header ehead, Section_header shead, int offset, Args a
     return ret;
 }
 
-Hashmap **grab_symbol_table(Elf_header elf_header, Section_header *section_header, Args args) {
+Hashmap **grab_symbol_table(Elf_header elf_header, Section_header *section_header, Args args,
+        char *fn) {
     Hashmap **ret = hashmap_new();
-    FILE *fd = fopen(args.path.filepath, "r");
+    FILE *fd = fopen(fn, "r");
     Section_header sh_symtab = get_section_entry(section_header, elf_header, 0x2);
     int entries = sh_symtab.sh_size / sh_symtab.sh_entsize;
     navigate_fd_to_symbol_table(fd, sh_symtab);
@@ -62,7 +63,7 @@ Hashmap **grab_symbol_table(Elf_header elf_header, Section_header *section_heade
         Elf64_Sym symtab_entry = read_symbol_entry(fd, sh_symtab, elf_header);
         memcpy(entry, &symtab_entry, sizeof(Elf64_Sym));
 
-        char *name = get_symbol_name(elf_header, section_header[sh_symtab.sh_link], symtab_entry.st_name, args);
+        char *name = get_symbol_name(elf_header, section_header[sh_symtab.sh_link], symtab_entry.st_name, args, fn);
         hashmap_insert(name, entry, ret);
     }
     printf("done!\n");

--- a/src/dump_symbol_table.c
+++ b/src/dump_symbol_table.c
@@ -39,7 +39,6 @@ char *get_symbol_name(Elf_header ehead, Section_header shead, int offset, Args a
     }
 
     len = strlen(buf);
-    printf("%s, %d\n", buf, len);
 
     char *ret = calloc(len + 1, sizeof(char));
     for (int i = 0; i < len; i++) {

--- a/src/main.c
+++ b/src/main.c
@@ -4,36 +4,14 @@
 
 #include "../headers/parse_args.h"
 #include "../headers/misc.h"
-#include "../headers/dump_elf_header.h"
-#include "../headers/dump_section_header.h"
-#include "../headers/dump_program_header.h"
-#include "../headers/dump_symbol_table.h"
+#include "../headers/obj_metadata.h"
 
 int main(int argc, char *argv[]) {
     printf("== hello, prom == \n\n");
     Args args = parse_args(argc, argv);
-
     print_args(args);
-
-    Elf_header elf_header = grab_elf_header(args);
-    if (is_32_bit(elf_header)) fatal_error("Linker only will work with 64-bit systems");
-    Section_header *section_headers = grab_all_section_headers(elf_header, args);
-    bool proghead_exists = program_header_exists(elf_header);
-    Program_header *program_headers = NULL;
-    if (proghead_exists) program_headers = grab_program_headers(elf_header, args);
-    
-    Hashmap **symtab = grab_symbol_table(elf_header, section_headers, args);
-    hashmap_visualiser(symtab);
-
-    if (!proghead_exists && args.dump_program_header) fatal_error("-p doesn't work with object files without program headers!");
-    if (args.dump_header) dump_header(elf_header);
-    if (args.dump_section_header) dump_section_headers(section_headers, elf_header, args);
-    if (args.dump_program_header) dump_program_headers(program_headers, elf_header, args);
-
-
-    if (program_headers != NULL) free(program_headers);
-    free(section_headers);
-    hashmap_free(symtab);
+    Objdata *obj = get_objdata(&args);
+    dump_objdata(obj, args);
 
     return 0;
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -42,10 +42,14 @@ void print_args(Args args) {
     printf("arg flags:\n");
     printf("- dump header: %d\n", args.dump_header);
 
-    printf("- file:\n");
-    printf("\t- filename: %s\n", args.path.filepath);
-    printf("\t- set: %d\n", args.path.set);
-    printf("\t- len: %d\n", args.path.size);
+    Filepath *curr = args.path;
+    while (curr != NULL) {
+        printf("- file:\n");
+        printf("\t- filename: %s\n", curr->filepath);
+        printf("\t- set: %d\n", curr->set);
+        printf("\t- len: %d\n", curr->size);
+        curr = curr->next;
+    }
 }
 
 // reads nbytes before we have parsed an elf header
@@ -124,8 +128,8 @@ uint64_t read_nbytes_better(Elf_header header, FILE *fd, int bytes, bool variabl
 }
 
 // debug function to dump nbytes from a file offset.
-void DEBUG_DUMP_NBYTES(int offset, int n, Args args) {
-    FILE *fd = fopen(args.path.filepath, "r");
+void DEBUG_DUMP_NBYTES(int offset, int n, Args args, char *fn) {
+    FILE *fd = fopen(fn, "r");
 
     lseek(fileno(fd), offset, SEEK_SET);
     for (int i = 0 ; i < n; i++) {

--- a/src/objmeta.c
+++ b/src/objmeta.c
@@ -18,12 +18,16 @@ void obj_clean(Objdata *obj) {
 }
 
 void dump_objdata(Objdata *obj, Args args) {
-    bool proghead_exists = program_header_exists(obj->eheader);
-    if (!proghead_exists && args.dump_program_header) fatal_error("-p doesn't work with object files without program headers!");
-    if (args.dump_header) dump_header(obj->eheader);
-    if (args.dump_section_header) dump_section_headers(obj->sheaders, obj->eheader, args, obj->path);
-    if (args.dump_program_header) dump_program_headers(obj->pheaders, obj->eheader, args);
-    if (args.dump_symtab) hashmap_visualiser(obj->symtab);
+    Objdata *curr = obj;
+    while (curr != NULL) {
+        bool proghead_exists = program_header_exists(curr->eheader);
+        if (!proghead_exists && args.dump_program_header) fatal_error("-p doesn't work with object files without program headers!");
+        if (args.dump_header) dump_header(curr->eheader);
+        if (args.dump_section_header) dump_section_headers(curr->sheaders, curr->eheader, args, curr->path);
+        if (args.dump_program_header) dump_program_headers(curr->pheaders, curr->eheader, args);
+        if (args.dump_symtab) hashmap_visualiser(curr->symtab);
+        curr = curr->next;
+    }
 }
 
 Objdata *get_objdata(Args *args) {

--- a/src/objmeta.c
+++ b/src/objmeta.c
@@ -1,0 +1,71 @@
+#include <stdlib.h>
+
+#include "../headers/obj_metadata.h"
+#include "../headers/parse_args.h"
+#include "../headers/misc.h"
+#include "../headers/dump_elf_header.h"
+#include "../headers/dump_section_header.h"
+#include "../headers/dump_program_header.h"
+#include "../headers/dump_symbol_table.h"
+
+void obj_clean(Objdata *obj) {
+    /*
+    if (program_headers != NULL) free(program_headers);
+    free(section_headers);
+    hashmap_free(symtab);
+
+    */
+}
+
+void dump_objdata(Objdata *obj, Args args) {
+    bool proghead_exists = program_header_exists(obj->eheader);
+    if (!proghead_exists && args.dump_program_header) fatal_error("-p doesn't work with object files without program headers!");
+    if (args.dump_header) dump_header(obj->eheader);
+    if (args.dump_section_header) dump_section_headers(obj->sheaders, obj->eheader, args, obj->path);
+    if (args.dump_program_header) dump_program_headers(obj->pheaders, obj->eheader, args);
+    if (args.dump_symtab) hashmap_visualiser(obj->symtab);
+}
+
+Objdata *get_objdata(Args *args) {
+    Filepath *curr = args->path;
+    Objdata *head = NULL;
+
+    while (curr != NULL) {
+        Elf_header elf_header = grab_elf_header(*args, curr->filepath);
+        if (is_32_bit(elf_header)) fatal_error("Linker only will work with 64-bit systems");
+        Section_header *section_headers = grab_all_section_headers(elf_header, *args, curr->filepath);
+        Program_header *program_headers = NULL;
+        bool proghead_exists = program_header_exists(elf_header);
+        if (proghead_exists) program_headers = grab_program_headers(elf_header, *args, curr->filepath);
+        Hashmap **symtab = grab_symbol_table(elf_header, section_headers, *args, curr->filepath);
+
+        Objdata *curr_obj = head;
+        Objdata *new = new_objdata(elf_header, section_headers, program_headers, symtab, curr->filepath);
+        if (curr_obj == NULL) {
+            head = new;
+            curr = curr->next;
+            continue;
+        }
+
+        while (curr_obj->next != NULL) {
+            curr_obj = curr_obj->next;
+        }
+        curr_obj->next = new;
+
+        curr = curr->next;
+    }
+    return head;
+}
+
+Objdata *new_objdata(Elf_header e, Section_header *s, Program_header *p, Hashmap **sym, char *fn) {
+    Objdata *ret = malloc(sizeof(Objdata));
+
+    ret->next = NULL;
+    ret->symtab = sym;
+    ret->path = fn;
+    ret->eheader = e;
+    ret->sheaders = s;
+    ret->pheaders = p;
+
+    return ret;
+}

--- a/src/parse_args.c
+++ b/src/parse_args.c
@@ -31,7 +31,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             arguments->dump_symtab = 1;
             break;
         case ARGP_KEY_ARG:
-            char message_buffer[1000];
+            char message_buffer[10000] = {};
             char *cur_arg = arg;
 
             snprintf(message_buffer, sizeof(message_buffer), "ERROR: filepath '%s' doesn't exist!", cur_arg);
@@ -43,26 +43,42 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             char *filepath = malloc(sizeof(char) * len);
             strcpy(filepath, cur_arg);
 
-            arguments->path.size = len;
-            arguments->path.filepath = filepath;
-            arguments->path.set = true;
-            return 0;
+            Filepath *curr = arguments->path;
+            if (curr == NULL) {
+                arguments->file_count++;
+                arguments->path = malloc(sizeof(Filepath));
+                arguments->path->size = len;
+                arguments->path->filepath = filepath;
+                arguments->path->set = true;
+                arguments->path->next = NULL;
+                return 0;
+            }
+
+            while (curr->next != NULL) {
+                curr = curr->next;
+            }
+
+            arguments->file_count++;
+            curr->next = malloc(sizeof(Filepath));
+            curr->size = len;
+            curr->filepath = filepath;
+            curr->set = true;
+            curr->next = NULL;
         default:
             return ARGP_ERR_UNKNOWN;
     }
     return 0;
 }
 
-static struct argp argp = { options, parse_opt, "ARG1 ARG2", "A program to demonstrate argp" };
+static struct argp argp = { options, parse_opt, "[ELF file]", "A hybrid elf linker/dumper" };
 Args parse_args(int argc, char *argv[]) {
     Args ret = {
         .dump_header = false,
         .dump_section_header = false,
         .dump_program_header = false,
         .dump_symtab = false,
-        .path = {
-            .set = false,
-        },
+        .file_count = 0,
+        .path = NULL,
     };
     argp_parse(&argp, argc, argv, 0, 0, &ret);
     return ret;

--- a/src/parse_args.c
+++ b/src/parse_args.c
@@ -36,6 +36,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 
             snprintf(message_buffer, sizeof(message_buffer), "ERROR: filepath '%s' doesn't exist!", cur_arg);
             // assume is the filepath if not a flag
+            printf("meow\n");
             if (!file_exists(cur_arg)) { fatal_error(message_buffer); }
             if (!file_readable(cur_arg)) { fatal_error("ERROR: unable to read file!"); }
 
@@ -53,6 +54,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                 arguments->path->next = NULL;
                 return 0;
             }
+            printf("meow2\n");
 
             while (curr->next != NULL) {
                 curr = curr->next;
@@ -64,6 +66,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             curr->filepath = filepath;
             curr->set = true;
             curr->next = NULL;
+            break;
         default:
             return ARGP_ERR_UNKNOWN;
     }

--- a/src/parse_args.c
+++ b/src/parse_args.c
@@ -36,7 +36,6 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 
             snprintf(message_buffer, sizeof(message_buffer), "ERROR: filepath '%s' doesn't exist!", cur_arg);
             // assume is the filepath if not a flag
-            printf("meow\n");
             if (!file_exists(cur_arg)) { fatal_error(message_buffer); }
             if (!file_readable(cur_arg)) { fatal_error("ERROR: unable to read file!"); }
 
@@ -52,9 +51,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                 arguments->path->filepath = filepath;
                 arguments->path->set = true;
                 arguments->path->next = NULL;
-                return 0;
+                break;
             }
-            printf("meow2\n");
 
             while (curr->next != NULL) {
                 curr = curr->next;
@@ -62,10 +60,10 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 
             arguments->file_count++;
             curr->next = malloc(sizeof(Filepath));
-            curr->size = len;
-            curr->filepath = filepath;
-            curr->set = true;
-            curr->next = NULL;
+            curr->next->size = len;
+            curr->next->filepath = filepath;
+            curr->next->set = true;
+            curr->next->next = NULL;
             break;
         default:
             return ARGP_ERR_UNKNOWN;

--- a/src/parse_args.c
+++ b/src/parse_args.c
@@ -6,7 +6,54 @@
 #include "../headers/parse_args.h"
 #include "../headers/misc.h"
 
+static struct argp_option options[] = {
+    {"dump-elf-header",       'e', 0, 0,  "Dumps the elf header to stdout" },
+    {"dump-section-header",   's', 0, 0,  "Dumps the section header to stdout" },
+    {"dump-program-header",   'p', 0, 0,  "Dumps the program header to stdout" },
+    {"dump-symbol-table",     't', 0, 0,  "Dumps the symbol table to stdout" },
+    { 0 }
+};
 
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+    struct args *arguments = state->input;
+
+    switch (key) {
+        case 'e':
+            arguments->dump_header = 1;
+            break;
+        case 's':
+            arguments->dump_section_header = 1;
+            break;
+        case 'p':
+            arguments->dump_program_header = 1;
+            break;
+        case 't':
+            arguments->dump_symtab = 1;
+            break;
+        case ARGP_KEY_ARG:
+            char message_buffer[1000];
+            char *cur_arg = arg;
+
+            snprintf(message_buffer, sizeof(message_buffer), "ERROR: filepath '%s' doesn't exist!", cur_arg);
+            // assume is the filepath if not a flag
+            if (!file_exists(cur_arg)) { fatal_error(message_buffer); }
+            if (!file_readable(cur_arg)) { fatal_error("ERROR: unable to read file!"); }
+
+            int len = strlen(cur_arg);
+            char *filepath = malloc(sizeof(char) * len);
+            strcpy(filepath, cur_arg);
+
+            arguments->path.size = len;
+            arguments->path.filepath = filepath;
+            arguments->path.set = true;
+            return 0;
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static struct argp argp = { options, parse_opt, "ARG1 ARG2", "A program to demonstrate argp" };
 Args parse_args(int argc, char *argv[]) {
     Args ret = {
         .dump_header = false,
@@ -17,7 +64,10 @@ Args parse_args(int argc, char *argv[]) {
             .set = false,
         },
     };
+    argp_parse(&argp, argc, argv, 0, 0, &ret);
+    return ret;
 
+    /*
     for (int i = 1; i < argc; i++) {
         char *cur_arg = argv[i];
 
@@ -50,4 +100,5 @@ Args parse_args(int argc, char *argv[]) {
     if (!ret.path.set) { fatal_error("ERROR: user did not supply object filepath"); }
 
     return ret;
+    */
 }


### PR DESCRIPTION
this pr aims to:
- overhaul the old arg parsing to use gnu `argp` instead
- allow multiple files to be parsed
- create new `objdata` to hold metadata about files as a linkedlist
- allow metadata dumping of multiple files
- fix bugs